### PR TITLE
Move richindex/market classes

### DIFF
--- a/curve/src/evcel/curve/RichFuturesMarket.scala
+++ b/curve/src/evcel/curve/RichFuturesMarket.scala
@@ -1,15 +1,14 @@
-package evcel.valuation
+package evcel.curve
 
-import evcel.curve.ValuationContext
-import evcel.referencedata.calendar.Calendar
 import evcel.daterange.{Day, Month}
-import scala.util.{Either, Left, Right}
-import evcel.utils.{EvcelFail, GeneralEvcelFail}
-import evcel.instrument.{Future, HedgeInstrument}
-import evcel.referencedata.{FuturesExpiryRule, ReferenceData}
-import evcel.referencedata.market.{FuturesContractIndexLabel, FuturesMarket, VolumeCalcRule}
 import evcel.quantity.{Qty, QtyConversions}
+import evcel.referencedata.calendar.Calendar
+import evcel.referencedata.market.{FuturesContractIndexLabel, FuturesMarket, VolumeCalcRule}
+import evcel.referencedata.{FuturesExpiryRule, ReferenceData}
 import evcel.utils.EitherUtils._
+import evcel.utils.{EvcelFail, GeneralEvcelFail}
+
+import scala.util.{Either, Left, Right}
 
 case class RichFuturesMarket(
   market : FuturesMarket,
@@ -52,12 +51,6 @@ case class RichFuturesMarket(
 
   def optionExpiryDay(month : Month) : Either[EvcelFail, Day] = expiryRule.optionExpiryDay(month)
   def lastTradingDay(month: Month) = expiryRule.futureExpiryDay(month)
-
-  def unitHedge(month : Month) = {
-    HedgeInstrument.intern(
-      Future(market.name, month, strike = Qty(0, priceUOM), volume = Qty(1, quotedVolumeUOM))
-    )
-  }
 }
 
 object RichFuturesMarket{

--- a/curve/src/evcel/curve/RichSpotMarket.scala
+++ b/curve/src/evcel/curve/RichSpotMarket.scala
@@ -1,11 +1,12 @@
-package evcel.valuation
+package evcel.curve
 
-import evcel.referencedata.calendar.Calendar
-import scala.util.Either
-import evcel.utils.EvcelFail
-import evcel.utils.EitherUtils._
 import evcel.referencedata.ReferenceData
+import evcel.referencedata.calendar.Calendar
 import evcel.referencedata.market.{SpotMarket, VolumeCalcRule}
+import evcel.utils.EitherUtils._
+import evcel.utils.EvcelFail
+
+import scala.util.Either
 
 case class RichSpotMarket(
   market : SpotMarket,

--- a/curve/src/evcel/curve/ValuationContext.scala
+++ b/curve/src/evcel/curve/ValuationContext.scala
@@ -21,9 +21,11 @@ case class ValuationContext(atomic: AtomicEnvironment, refData: ReferenceData, p
   def discountRate(currency: UOM, day: Day) =
     atomic(DiscountRateIdentifier(currency, day))
   def fixing(index: Index, observationDay: Day): Either[EvcelFail, Qty] = {
-      index.observable(refData, observationDay).flatMap(
+    RichIndex(refData, index).flatMap { ri =>
+      ri.observable(refData, observationDay).flatMap(
         ndx => atomic(PriceFixingIdentifier(ndx, observationDay))
       )
+    }
   }
   def fixing(spotMarket: SpotMarket, observationDay: Day): Either[EvcelFail, Qty] =
     fixing(SpotIndex(spotMarket), observationDay)

--- a/curve/src/evcel/curve/environment/MarketDay.scala
+++ b/curve/src/evcel/curve/environment/MarketDay.scala
@@ -6,6 +6,8 @@ case class MarketDay(day: Day, timeOfDay: TimeOfDay) extends Ordered[MarketDay] 
     case 0 => timeOfDay.compare(that.timeOfDay)
     case o => o
   }
+
+  def nextDay = copy(day = day.next)
 }
 
 object MarketDay {

--- a/curve/tests/evcel/curve/RichIndexTest.scala
+++ b/curve/tests/evcel/curve/RichIndexTest.scala
@@ -1,11 +1,12 @@
-package evcel.referencedata.market
+package evcel.curve
 
 import evcel.daterange.{Day, Month}
 import evcel.referencedata.Level
+import evcel.referencedata.market.{FuturesContractIndex, FuturesContractIndexLabel, Index, TestMarkets}
 import evcel.utils.EitherTestPimps
 import org.scalatest.{FunSuite, ShouldMatchers}
 
-class IndexTest extends FunSuite with ShouldMatchers with EitherTestPimps{
+class RichIndexTest extends FunSuite with ShouldMatchers with EitherTestPimps{
 
    test("test FFPI to FCI") {
      val refData = TestMarkets.testRefData
@@ -25,9 +26,10 @@ class IndexTest extends FunSuite with ShouldMatchers with EitherTestPimps{
 
      def test(ndx: Index, observationDay: Day,
               observedMonth: Month, observedOnPrevDay: Month, observedOnNextDay: Month) = {
-       ndx.observable(refData, observationDay) shouldEqual Right(fci(observedMonth))
-       ndx.observable(refData, observationDay.previous) shouldEqual Right(fci(observedOnPrevDay))
-       ndx.observable(refData, observationDay.next) shouldEqual Right(fci(observedOnNextDay))
+       val richIndex = RichIndex(refData, ndx).R
+       richIndex.observable(refData, observationDay) shouldEqual Right(fci(observedMonth))
+       richIndex.observable(refData, observationDay.previous) shouldEqual Right(fci(observedOnPrevDay))
+       richIndex.observable(refData, observationDay.next) shouldEqual Right(fci(observedOnNextDay))
      }
 
      test(wti10, ltd, month, observedOnPrevDay = month, observedOnNextDay = month + 1)

--- a/referencedata/src/evcel/referencedata/market/Index.scala
+++ b/referencedata/src/evcel/referencedata/market/Index.scala
@@ -11,8 +11,6 @@ trait Index {
   def label: IndexLabel
   def level: Level
 
-  def observable(refData: ReferenceData, observationDay: Day): Either[EvcelFail, Observable]
-
   override def toString: String = label.indexName
 }
 
@@ -44,36 +42,11 @@ case class FuturesFrontPeriodIndex(label: FuturesFrontPeriodIndexLabel, market: 
 
   def rollEarlyDays = label.rollEarlyDays
   def nearby = label.nearby
-
-  override def observable(refData: ReferenceData, observationDay: Day): Either[EvcelFail, FuturesContractIndex] = {
-    refData.futuresExpiryRule(market.name).flatMap {
-      expRule =>
-        refData.calendar(market.name).flatMap {
-          cal =>
-            val containingMonth = observationDay.containingMonth
-            val months = containingMonth.to(containingMonth + 20).view
-            val month = months.find(month => expRule.futureExpiryDay(month) match {
-              case Left(_) => true // failed to get expiry day, so stop here
-              case Right(day) =>
-                val adjustedLTD = cal.addBusinessDays(day, -label.rollEarlyDays)
-                adjustedLTD >= observationDay
-            }).map(_  + (label.nearby - 1))
-
-            month.toRight(GeneralEvcelFail(s"Failed to convert $this to FuturesContractIndex")).flatMap {
-              month => expRule.futureExpiryDay(month).map{
-                _ => FuturesContractIndex(FuturesContractIndexLabel(market.name, month), market, level)
-              }
-            }
-        }
-    }
-  }
 }
 
 case class FuturesContractIndex(label: FuturesContractIndexLabel, market: FuturesMarket, level: Level)
   extends Index with Observable {
   override def priceUOM: UOM = market.priceUOM
-
-  override def observable(refData: ReferenceData, observationDay: Day): Either[EvcelFail, Observable] = Right(this)
 }
 
 case class SpotIndex(market: SpotMarket) extends Index with Observable {
@@ -82,8 +55,6 @@ case class SpotIndex(market: SpotMarket) extends Index with Observable {
   override def label: IndexLabel = SpotMarketIndexLabel(market.name)
 
   override def level = market.level
-
-  override def observable(refData: ReferenceData, observationDay: Day): Either[EvcelFail, Observable] = Right(this)
 }
 
 case class IndexSpread(spread: IndexLabelSpread, level1: Level, level2: Level)

--- a/reports/tests/evcel/report/ValuationTableBuilderTests.scala
+++ b/reports/tests/evcel/report/ValuationTableBuilderTests.scala
@@ -9,7 +9,7 @@ import evcel.quantity.{Qty, Percent}
 import evcel.quantity.Qty._
 import evcel.quantity.UOM._
 import evcel.valuation._
-import evcel.curve.{UnitTestingEnvironment, ValuationContext}
+import evcel.curve.{RichFuturesMarket, RichIndex, UnitTestingEnvironment, ValuationContext}
 import evcel.curve.marketdata.{FuturesPriceData, MarketDataTest, Act365}
 import scala.language.reflectiveCalls
 import evcel.quantity.utils.QuantityTestUtils._

--- a/valuation/src/evcel/valuation/HedgingStrategy.scala
+++ b/valuation/src/evcel/valuation/HedgingStrategy.scala
@@ -4,7 +4,7 @@ import evcel.referencedata.Level
 import evcel.referencedata.market.{IndexLabelSpread, FuturesDerivedIndexLabel}
 import evcel.utils.{EvcelFail, EitherUtils}
 import evcel.instrument._
-import evcel.curve.{ValuationContext, EnvironmentParams}
+import evcel.curve._
 import evcel.daterange.{DateRange, Day, Month}
 import evcel.utils.EitherUtils._
 import scala.util.{Either, Left, Right}

--- a/valuation/src/evcel/valuation/RichValuationFuturesMarket.scala
+++ b/valuation/src/evcel/valuation/RichValuationFuturesMarket.scala
@@ -1,0 +1,22 @@
+package evcel.valuation
+
+import evcel.curve.RichFuturesMarket
+import evcel.daterange.Month
+import evcel.instrument._
+import evcel.quantity.Qty
+
+trait RichValuationFuturesMarket {
+  implicit class RichValuationFuturesMarket(richMarket: RichFuturesMarket) {
+
+    def unitHedge(month : Month) = {
+      HedgeInstrument.intern(
+        Future(
+          richMarket.market.name,
+          month,
+          strike = Qty(0, richMarket.priceUOM),
+          volume = Qty(1, richMarket.quotedVolumeUOM)
+        )
+      )
+    }
+  }
+}

--- a/valuation/src/evcel/valuation/RichValuationIndex.scala
+++ b/valuation/src/evcel/valuation/RichValuationIndex.scala
@@ -1,0 +1,56 @@
+package evcel.valuation
+
+import evcel.curve.{RichIndexSpread, ValuationContext, RichIndex}
+import evcel.daterange.DateRange
+import evcel.instrument._
+import evcel.quantity.{UOM, Qty}
+import evcel.utils.EvcelFail
+import evcel.utils.EitherUtils._
+import scala.util.Either
+
+trait RichValuationIndex {
+  implicit class RichValuationIndex(richIndex: RichIndex) {
+    def unitHedge(averagingPeriod : DateRange) = {
+      val swap = CommoditySwap(
+        richIndex.index.label, averagingPeriod,
+        Qty(0, richIndex.priceUOM),
+        Qty(1, richIndex.quotedVolumeUOM),
+        // TODO - should default biz days be reference data?
+        bizDaysToSettlement = None
+      )
+      HedgeInstrument.intern(swap)
+    }
+  }
+
+  implicit class RichValuationSpreadIndex(richIndex: RichIndexSpread) {
+    def index1 = richIndex.index1
+    def index2 = richIndex.index2
+
+    def spreadPrice(
+        vc : ValuationContext,
+        rule : SwapSpreadPricingRule,
+        period : DateRange,
+        expectedUOM : UOM) : Either[EvcelFail, Qty] = {
+        val List(index1Calendar, index2Calendar) = rule match {
+          case CommonSwapPricingRule =>
+            val cal = CommonSwapPricingRule.calendar(index1.calendar, index2.calendar)
+            List(cal, cal)
+          case NonCommonSwapPricingRule =>
+            List(index1.calendar, index2.calendar)
+        }
+        val (obsDays1, obsDays2) = (
+          period.days.filter(index1Calendar.isBusinessDay),
+          period.days.filter(index2Calendar.isBusinessDay)
+        )
+
+        for {
+          p1 <- index1.averagePrice(vc, obsDays1)
+          p1_converted <- p1.in(expectedUOM, index1.marketConversions)
+          p2 <- index2.averagePrice(vc, obsDays2)
+          p2_converted <- p2.in(expectedUOM, index2.marketConversions)
+        }
+          yield
+            p1_converted - p2_converted
+      }
+  }
+}

--- a/valuation/src/evcel/valuation/SVDPositions.scala
+++ b/valuation/src/evcel/valuation/SVDPositions.scala
@@ -1,6 +1,6 @@
 package evcel.valuation
 
-import evcel.curve.ValuationContext
+import evcel.curve.{RichIndex, ValuationContext}
 import evcel.curve.environment.{MarketDay, PriceIdentifier}
 import evcel.valuation.Valuer._
 import evcel.instrument._

--- a/valuation/src/evcel/valuation/Valuer.scala
+++ b/valuation/src/evcel/valuation/Valuer.scala
@@ -1,6 +1,6 @@
 package evcel.valuation
 
-import evcel.curve.ValuationContext
+import evcel.curve.{RichFuturesMarket, RichIndexSpread, RichIndex, ValuationContext}
 import evcel.curve.environment.{PriceIdentifier, AtomicDatumIdentifier}
 import evcel.instrument._
 import evcel.quantity.{Qty, BDQty, DblQty}

--- a/valuation/src/evcel/valuation/package.scala
+++ b/valuation/src/evcel/valuation/package.scala
@@ -1,0 +1,5 @@
+package evcel
+
+package object valuation extends RichValuationIndex with RichValuationFuturesMarket {
+
+}

--- a/valuation/tests/evcel/valuation/FuturePositionTest.scala
+++ b/valuation/tests/evcel/valuation/FuturePositionTest.scala
@@ -1,5 +1,6 @@
 package evcel.valuation
 
+import evcel.curve.RichFuturesMarket
 import evcel.daterange.PeriodLabel
 import evcel.valuation.Valuer._
 import evcel.quantity.UOM._

--- a/valuation/tests/evcel/valuation/PositionTest.scala
+++ b/valuation/tests/evcel/valuation/PositionTest.scala
@@ -1,5 +1,6 @@
 package evcel.valuation
 
+import evcel.curve.RichIndex
 import evcel.quantity.Qty
 import evcel.quantity.UOM._
 

--- a/valuation/tests/evcel/valuation/SwapLikeValuerTest.scala
+++ b/valuation/tests/evcel/valuation/SwapLikeValuerTest.scala
@@ -1,5 +1,6 @@
 package evcel.valuation
 
+import evcel.curve.{RichSpotMarket, RichFuturesMarket, RichIndexSpread, RichIndex}
 import evcel.curve.curves.{DiscountRateIdentifier, FuturesPriceIdentifier, SpotPriceIdentifier}
 import evcel.instrument.{CommoditySwapLookalike, CommoditySwap}
 import evcel.quantity.Qty

--- a/valuation/tests/evcel/valuation/SwapPositionTest.scala
+++ b/valuation/tests/evcel/valuation/SwapPositionTest.scala
@@ -1,5 +1,6 @@
 package evcel.valuation
 
+import evcel.curve.{RichFuturesMarket, RichIndex}
 import evcel.daterange._
 import evcel.referencedata.Level
 import evcel.referencedata.market.{FuturesFrontPeriodIndexLabel, IndexLabel}

--- a/valuation/tests/evcel/valuation/ValuationTest.scala
+++ b/valuation/tests/evcel/valuation/ValuationTest.scala
@@ -4,7 +4,7 @@ import evcel.curve.curves._
 import evcel.curve.environment.{SpotFXIdentifier, MarketDay}
 import evcel.curve.environment.MarketDay._
 import evcel.curve.marketdata.Act365
-import evcel.curve.{UnitTestingEnvironment, ValuationContext}
+import evcel.curve._
 import evcel.daterange.DateRangeSugar._
 import evcel.daterange._
 import evcel.instrument._

--- a/valuation/tests/evcel/valuation/ValuerTest.scala
+++ b/valuation/tests/evcel/valuation/ValuerTest.scala
@@ -1,6 +1,6 @@
 package evcel.valuation
 
-import evcel.curve.UnitTestingEnvironment
+import evcel.curve.{RichFuturesMarket, UnitTestingEnvironment}
 import evcel.curve.curves.{FuturesVolIdentifier, DiscountRateIdentifier, FuturesPriceIdentifier}
 import evcel.daterange.DateRangeSugar.{Oct, Nov}
 import evcel.curve.environment.MarketDay._


### PR DESCRIPTION
Moved into curve where they seem better suited. The methods
that were needed in valuation are now a pimp.

Added forward state for PriceFixingIndex and tests.