### PR TITLE
upgrade to scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 scala:
-  - 2.10.4
+  - 2.11.5
 sudo: false
 cache:
   directories:

--- a/config/logback-unit-tests.xml
+++ b/config/logback-unit-tests.xml
@@ -1,7 +1,9 @@
-<!-- The logback file used during the running of maker's own unit tests
+<!-- The logback file used during the running of maker/sbt's own unit tests
      Quietens the logging somewhat-->
 
-<configuration scan="true" scanPeriod="3 seconds">
+<configuration debug="false" >
+  <logger name="state.change.logger" level="OFF"/> 
+  <logger name="kafka.producer.async.DefaultEventHandler" level="OFF"/>
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>maker.log</file>
@@ -17,6 +19,10 @@
         
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
+      <!-- 
+          Add %logger to the log pattern to find the name of any 3rd party loggers
+          you want to exclude 
+      -->
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
       <immediateFlush>true</immediateFlush>
     </encoder>

--- a/curve/tests/evcel/curve/RichIndexTest.scala
+++ b/curve/tests/evcel/curve/RichIndexTest.scala
@@ -4,9 +4,9 @@ import evcel.daterange.{Day, Month}
 import evcel.referencedata.Level
 import evcel.referencedata.market.{FuturesContractIndex, FuturesContractIndexLabel, Index, TestMarkets}
 import evcel.utils.EitherTestPimps
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 
-class RichIndexTest extends FunSuite with ShouldMatchers with EitherTestPimps{
+class RichIndexTest extends FunSuite with Matchers with EitherTestPimps{
 
    test("test FFPI to FCI") {
      val refData = TestMarkets.testRefData

--- a/curve/tests/evcel/curve/ValuationContextTests.scala
+++ b/curve/tests/evcel/curve/ValuationContextTests.scala
@@ -9,14 +9,12 @@ import evcel.quantity.UOM._
 import evcel.quantity.{Percent, Qty}
 import evcel.quantity.Qty._
 import evcel.referencedata.market.{TestMarkets, FXPair}
-import org.scalatest.{FunSuite, FunSpecLike, ShouldMatchers}
+import org.scalatest.{Matchers, FunSuite, FunSpecLike}
 import evcel.quantity.utils.QuantityTestUtils._
 import scala.language.reflectiveCalls
 import evcel.utils.EitherTestPimps
-import org.scalatest.matchers.ShouldMatchers
 
-
-class ValuationContextTests extends FunSuite with MarketDataTest with ShouldMatchers with EitherTestPimps{
+class ValuationContextTests extends FunSuite with MarketDataTest with Matchers with EitherTestPimps{
 
   val vc = UnitTestingEnvironment.fromMarketData(
     (10 / Sep / 2014).endOfDay,
@@ -49,8 +47,8 @@ class ValuationContextTests extends FunSuite with MarketDataTest with ShouldMatc
         vc.discountRate(GBP, vc.marketDay.day + 2).R / vc.discountRate(USD, vc.marketDay.day + 2).R
 
     vc.todayFX(FXPair(GBP, EUR)).R should be
-      (vc.spotFX(FXPair(USD, GBP)).R.invert * vc.spotFX(FXPair(USD, EUR)).R *
-        vc.discountRate(GBP, vc.marketDay.day + 2).R / vc.discountRate(EUR, vc.marketDay.day + 2).R +- 1e-9)
+      vc.spotFX(FXPair(USD, GBP)).R.invert * vc.spotFX(FXPair(USD, EUR)).R *
+        vc.discountRate(GBP, vc.marketDay.day + 2).R / vc.discountRate(EUR, vc.marketDay.day + 2).R +- 1e-9
   }
 
   test("forward fx") {
@@ -63,9 +61,9 @@ class ValuationContextTests extends FunSuite with MarketDataTest with ShouldMatc
         vc.discountRate(GBP, day).R / vc.discountRate(USD, day).R
 
     vc.forwardFX(FXPair(GBP, EUR), day).R should be
-      (vc.spotFX(FXPair(USD, GBP)).R.invert * vc.spotFX(FXPair(USD, EUR)).R *
+      vc.spotFX(FXPair(USD, GBP)).R.invert * vc.spotFX(FXPair(USD, EUR)).R *
         vc.discountRate(GBP, vc.marketDay.day + 2).R / vc.discountRate(EUR, vc.marketDay.day + 2).R *
-        vc.discountRate(GBP, day).R / vc.discountRate(EUR, day).R +- 1e-9)
+        vc.discountRate(GBP, day).R / vc.discountRate(EUR, day).R +- 1e-9
   }
 
   test("forwardState for discount curve") {

--- a/daterange/tests/evcel/daterange/ChronologicalTest.scala
+++ b/daterange/tests/evcel/daterange/ChronologicalTest.scala
@@ -1,8 +1,8 @@
 package evcel.daterange
 
-import org.scalatest.{ShouldMatchers, FunSuite}
+import org.scalatest.{Matchers, FunSuite}
 
-class ChronologicalTest extends FunSuite with ShouldMatchers {
+class ChronologicalTest extends FunSuite with Matchers {
 
   test("ordering") {
     // we can sort Seq[DateRange] even though DateRange is not ordered

--- a/daterange/tests/evcel/daterange/DateRangeTests.scala
+++ b/daterange/tests/evcel/daterange/DateRangeTests.scala
@@ -1,11 +1,11 @@
 package evcel.daterange
 
 import evcel.daterange.DateRangeSugar.{Jul, Jan, Mar}
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 
 import scala.language.reflectiveCalls
 
-class DateRangeTests extends FunSuite with ShouldMatchers {
+class DateRangeTests extends FunSuite with Matchers {
   test("days") {
     SimpleDateRange(1 / Mar / 2014, 1 / Mar / 2014).days.toList shouldEqual 1 / Mar / 2014 :: Nil
     SimpleDateRange(1 / Mar / 2014, 2 / Mar / 2014).days.toList shouldEqual 1 / Mar / 2014 :: 2 / Mar / 2014 :: Nil

--- a/eventstore/tests/evcel/eventstore/EventStoreTests.scala
+++ b/eventstore/tests/evcel/eventstore/EventStoreTests.scala
@@ -1,136 +1,129 @@
 package evcel.eventstore
 
-import org.scalatest.FunSpec
-import spray.json._
+import evcel.eventstore.EventStore._
 import evcel.eventstore.json.EventStoreJsonProtocol._
 import evcel.eventstore.kafka.KafkaTestUtils
-import EventStore._
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.language.postfixOps
-import org.scalatest.Matchers
-import scala.concurrent.Future
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.Collections
-import java.util.LinkedList
-import scala.collection.JavaConversions._
-import org.slf4j.LoggerFactory
-import org.slf4j.Logger
+import org.scalatest.{FunSuite, Matchers}
+import spray.json._
 
-class EventStoreTests extends FunSpec with Matchers{
-  
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.language.postfixOps
+
+
+class EventStoreTests extends FunSuite with Matchers {
+
   import scala.concurrent.ExecutionContext.Implicits.global
-  def makeEventStore(port : Int) = new EventStore[String, String]("EVENTS", port){
-    protected def createMessage(uuid : UUID_String, map : Map[String, String]) = {
+
+  def makeEventStore(port: Int) = new EventStore[String, String]("EVENTS", port) {
+    protected def createMessage(uuid: UUID_String, map: Map[String, String]) = {
       (uuid, map).toJson.prettyPrint
     }
-    protected def parseMessage(message : String) : (UUID_String, Map[String, String]) = {
+
+    protected def parseMessage(message: String): (UUID_String, Map[String, String]) = {
       message.parseJson.convertTo[(UUID_String, Map[String, String])]
     }
   }
-  def withEventStore(fn : EventStore[String, String] => Unit){
-    KafkaTestUtils.withTestKafka{
-      server => 
+
+  def withEventStore(fn: EventStore[String, String] => Unit) {
+    KafkaTestUtils.withTestKafka {
+      server =>
         KafkaTestUtils.createTopic(server, "EVENTS")
         val store = makeEventStore(server.config.port)
-        try{
+        try {
           fn(store)
         } finally {
           store.shutdown()
         }
     }
   }
-  describe("EventStore"){
 
-    it("Should have the correct offset after initialisation"){
-      KafkaTestUtils.withTestKafka{
-        server => 
-          KafkaTestUtils.createTopic(server, "EVENTS")
-          val (key, value) = ("Key", "Value")
-          val store1 = makeEventStore(server.config.port)
+  test("Should have the correct offset after initialisation") {
+    KafkaTestUtils.withTestKafka {
+      server =>
+        KafkaTestUtils.createTopic(server, "EVENTS")
+        val (key, value) = ("Key", "Value")
+        val store1 = makeEventStore(server.config.port)
 
-          store1.lastOffsetInHistory() should equal (Offset(0))
-          val promise = store1.write(key, value)
-          Await.result(promise, 10 seconds) should equal(Offset(1))
-          store1.lastOffsetInHistory() should equal (Offset(1))
-          store1.shutdown()
+        store1.lastOffsetInHistory() should equal(Offset(0))
+        val promise = store1.write(key, value)
+        Await.result(promise, 10 seconds) should equal(Offset(1))
+        store1.lastOffsetInHistory() should equal(Offset(1))
+        store1.shutdown()
 
-          val store2 = makeEventStore(server.config.port)
-          store2.lastOffsetInHistory() should equal (Offset(1))
-          store2.shutdown()
-          
-      }
-    }
+        val store2 = makeEventStore(server.config.port)
+        store2.lastOffsetInHistory() should equal(Offset(1))
+        store2.shutdown()
 
-    it("Shouldn't store duplicates"){
-      withEventStore{
-        store => 
-          Await.result(store.write("key1", "value1"), 6 seconds) should equal(Offset(1))
-          Await.result(store.write("key2", "value2"), 6 seconds) should equal(Offset(2))
-
-          // Write a duplicate - offset should not increase
-          Await.result(store.write("key1", "value1"), 6 seconds) should equal(Offset(2))
-          // latest version should also not change
-          store.lastOffsetInHistory() should equal (Offset(2))
-      }
-    }
-
-    it("Should be able to write things in parallel"){
-
-      KafkaTestUtils.withTestKafka{
-        server => 
-          val numEvents = 500
-          KafkaTestUtils.createTopic(server, "EVENTS")
-          val store1 = makeEventStore(server.config.port)
-          val futures : List[Future[Offset]] = (1 to numEvents).toList.map(i => 
-            Future{
-              var map = Map[String, String]()
-              for (j <- 1 to (math.random * 10).toInt){
-                val k = "Key " + (math.random * 10).toInt
-                val v = "Value " + (math.random * 10).toInt
-                map += (k -> v)
-              }
-              store1.write(map)
-            }.flatMap(identity)
-          )
-          
-          val maxOffset = Future.fold(futures)(Offset(0)){
-            case (Offset(l), Offset(r)) => 
-              Offset (l max r)
-          }
-          val result = Await.result(maxOffset, 20 seconds)
-          store1.shutdown()
-          
-          val store2 = makeEventStore(server.config.port)
-          store2.lastOffsetInHistory() should equal (result)
-          store2.shutdown()
-      }
     }
   }
 
-  it("Should throw an exception if what is read back doesn't match what was written"){
-    KafkaTestUtils.withTestKafka{
-      server => 
-        import spray.json._
-        import spray.json.RootJsonFormat
-        import spray.json.JsNumber
-        case class Broken(i : Int)
-        implicit val brokenFormat = new RootJsonFormat[Broken]{
-          def write(b : Broken) = JsNumber(b.i)
-          def read(value : JsValue)  = value match {
+  test("Shouldn't store duplicates") {
+    withEventStore {
+      store =>
+        Await.result(store.write("key1", "value1"), 6 seconds) should equal(Offset(1))
+        Await.result(store.write("key2", "value2"), 6 seconds) should equal(Offset(2))
+
+        // Write a duplicate - offset should not increase
+        Await.result(store.write("key1", "value1"), 6 seconds) should equal(Offset(2))
+        // latest version should also not change
+        store.lastOffsetInHistory() should equal(Offset(2))
+    }
+  }
+
+  test("Should be able to write things in parallel") {
+
+    KafkaTestUtils.withTestKafka {
+      server =>
+        val numEvents = 500
+        KafkaTestUtils.createTopic(server, "EVENTS")
+        val store1 = makeEventStore(server.config.port)
+        val futures: List[Future[Offset]] = (1 to numEvents).toList.map(i =>
+          Future {
+            var map = Map[String, String]()
+            for (j <- 1 to (math.random * 10).toInt) {
+              val k = "Key " + (math.random * 10).toInt
+              val v = "Value " + (math.random * 10).toInt
+              map += (k -> v)
+            }
+            store1.write(map)
+          }.flatMap(identity)
+        )
+
+        val maxOffset = Future.fold(futures)(Offset(0)) {
+          case (Offset(l), Offset(r)) =>
+            Offset(l max r)
+        }
+        val result = Await.result(maxOffset, 20 seconds)
+        store1.shutdown()
+
+        val store2 = makeEventStore(server.config.port)
+        store2.lastOffsetInHistory() should equal(result)
+        store2.shutdown()
+    }
+  }
+
+  test("Should throw an exception if what is read back doesn't match what was written") {
+    KafkaTestUtils.withTestKafka {
+      server =>
+        import spray.json.{JsNumber, RootJsonFormat, _}
+        case class Broken(i: Int)
+        implicit val brokenFormat = new RootJsonFormat[Broken] {
+          def write(b: Broken) = JsNumber(b.i)
+
+          def read(value: JsValue) = value match {
             case JsNumber(i) => Broken(i.toInt * 2)
             case _ => throw new RuntimeException("Unexpected type")
           }
         }
         val store = new EventStore[String, Broken](
           "Broken", server.config.port
-        ){
-          protected def createMessage(uuid : UUID_String, map : Map[String, Broken]) = {
+        ) {
+          protected def createMessage(uuid: UUID_String, map: Map[String, Broken]) = {
             (uuid, map).toJson.prettyPrint
           }
-          protected def parseMessage(message : String) : (UUID_String, Map[String, Broken]) = {
+
+          protected def parseMessage(message: String): (UUID_String, Map[String, Broken]) = {
             message.parseJson.convertTo[(UUID_String, Map[String, Broken])]
           }
         }
@@ -138,11 +131,11 @@ class EventStoreTests extends FunSpec with Matchers{
         val testWaitTime = 5 seconds
         // Broken(0) will be unchanged as 2 * 0 = 0
         val offset1 = Await.result(store.write("0", Broken(0)), testWaitTime)
-        offset1 should equal (Offset(1))
+        offset1 should equal(Offset(1))
 
 
         // Broken(1) will throw an error as the deserializer will return Broken(2)
-        intercept[RuntimeException]{
+        intercept[RuntimeException] {
           Await.result(store.write("1", Broken(1)), testWaitTime)
         }
         store.shutdown()

--- a/eventstore/tests/evcel/eventstore/kafka/KafkaTestUtils.scala
+++ b/eventstore/tests/evcel/eventstore/kafka/KafkaTestUtils.scala
@@ -3,51 +3,136 @@ package evcel.eventstore.kafka
 import java.net.ServerSocket
 import java.util.Properties
 import java.io.File
+import kafka.api.Request
+import kafka.producer.{DefaultPartitioner, Producer, ProducerConfig}
+import kafka.serializer.DefaultEncoder
 import kafka.server.KafkaServer
 import kafka.server.KafkaConfig
-import org.apache.zookeeper.server.ZooKeeperServer
-import org.apache.zookeeper.server.NIOServerCnxn
+import kafka.utils.ZkUtils
+import org.I0Itec.zkclient.ZkClient
+import org.apache.zookeeper.server.{NIOServerCnxnFactory, ZooKeeperServer, NIOServerCnxn}
 import java.net.InetSocketAddress
 import evcel.utils.FileUtils
 import kafka.admin.AdminUtils
 
 /**
-  * Mostly copied from Kafka's own unit tests
-  */
-object KafkaTestUtils{
+ * Mostly copied from Kafka's own unit tests
+ */
+object KafkaTestUtils {
 
-  def withTestKafka(fn : KafkaServer => Unit){
+  def withTestKafka(fn: KafkaServer => Unit) {
     val zookeeperPort = choosePort
     val zookeeper = new EmbeddedZookeeper(zookeeperPort)
     val kafkaLogDir = tempDir("kafka-test")
     val server = new KafkaServer(brokerConfig(kafkaLogDir, zookeeperPort))
     try {
       server.startup()
-      // This pause prevents some of the harmless but noisy log error messages that Kafka produces
-      // before it's quite ready to do its thing
-      Thread.sleep(1000)
       fn(server)
     } finally {
       server.shutdown()
+      server.awaitShutdown()
       zookeeper.shutdown()
       FileUtils.recursiveDelete(kafkaLogDir)
     }
   }
 
-  def createTopic(server : KafkaServer, topic : String){
-    AdminUtils.createTopic(server.zkClient, topic, partitions = 1, replicationFactor = 1)
-    Thread.sleep(2000) // Prevents 'Failed to collate messages by topic' error message from Kafka,
-                      // which is just noise, as Kafka invariably retries successfully
+  def createTopic(server: KafkaServer, topic: String, numPartitions: Int = 1) {
+    AdminUtils.createTopic(server.zkClient, topic, partitions = numPartitions, replicationFactor = 1)
+    (0 until numPartitions).map { case i =>
+      waitUntilMetadataIsPropagated(server :: Nil, topic, i)
+      i -> waitUntilLeaderIsElectedOrChanged(server.zkClient, topic, i)
+    }.toMap
   }
 
-  private def choosePort : Int = {
+  /**
+   * Wait until a valid leader is propagated to the metadata cache in each broker.
+   * It assumes that the leader propagated to each broker is the same.
+   * @param servers The list of servers that the metadata should reach to
+   * @param topic The topic name
+   * @param partition The partition Id
+   * @param timeout The amount of time waiting on this condition before assert to fail
+   * @return The leader of the partition.
+   */
+  private def waitUntilMetadataIsPropagated(servers: Seq[KafkaServer], topic: String, partition: Int, timeout: Long = 5000L): Int = {
+    var leader: Int = -1
+    waitUntilTrue(() =>
+      servers.foldLeft(true) {
+        (result, server) =>
+          val partitionStateOpt = server.apis.metadataCache.getPartitionInfo(topic, partition)
+          partitionStateOpt match {
+            case None => false
+            case Some(partitionState) =>
+              leader = partitionState.leaderIsrAndControllerEpoch.leaderAndIsr.leader
+              result && Request.isValidBrokerId(leader)
+          }
+      },
+      "Partition [%s,%d] metadata not propagated after %d ms".format(topic, partition, timeout),
+      waitTime = timeout)
+
+    leader
+  }
+
+  /**
+   * Wait until the given condition is true or throw an exception if the given wait time elapses.
+   */
+  private def waitUntilTrue(condition: () => Boolean, msg: String, waitTime: Long = 5000L): Boolean = {
+    val startTime = System.currentTimeMillis()
+    while (true) {
+      if (condition())
+        return true
+      if (System.currentTimeMillis() > startTime + waitTime)
+        sys.error(msg)
+      Thread.sleep(waitTime.min(100L))
+    }
+    // should never hit here
+    throw new RuntimeException("unexpected error")
+  }
+
+  /**
+   * If neither oldLeaderOpt nor newLeaderOpt is defined, wait until the leader of a partition is elected.
+   * If oldLeaderOpt is defined, it waits until the new leader is different from the old leader.
+   * If newLeaderOpt is defined, it waits until the new leader becomes the expected new leader.
+   * @return The new leader or assertion failure if timeout is reached.
+   */
+  private def waitUntilLeaderIsElectedOrChanged(zkClient: ZkClient, topic: String, partition: Int, timeoutMs: Long = 5000L,
+                                                oldLeaderOpt: Option[Int] = None, newLeaderOpt: Option[Int] = None): Option[Int] = {
+    require(!(oldLeaderOpt.isDefined && newLeaderOpt.isDefined), "Can't define both the old and the new leader")
+    val startTime = System.currentTimeMillis()
+    var isLeaderElectedOrChanged = false
+
+    var leader: Option[Int] = None
+    while (!isLeaderElectedOrChanged && System.currentTimeMillis() < startTime + timeoutMs) {
+      // check if leader is elected
+      leader = ZkUtils.getLeaderForPartition(zkClient, topic, partition)
+      leader match {
+        case Some(l) =>
+          if (newLeaderOpt.isDefined && newLeaderOpt.get == l) {
+            isLeaderElectedOrChanged = true
+          } else if (oldLeaderOpt.isDefined && oldLeaderOpt.get != l) {
+            isLeaderElectedOrChanged = true
+          } else if (!oldLeaderOpt.isDefined) {
+            isLeaderElectedOrChanged = true
+          } else {
+          }
+        case None =>
+      }
+      Thread.sleep(timeoutMs.min(100L))
+    }
+    if (!isLeaderElectedOrChanged)
+      sys.error("Timing out after %d ms since leader is not elected or changed for partition [%s,%d]"
+        .format(timeoutMs, topic, partition))
+
+    leader
+  }
+
+  def choosePort: Int = {
     val socket = new ServerSocket(0)
     val port = socket.getLocalPort
-    socket.close
+    socket.close()
     port
   }
 
-  private def brokerConfig(logDir : File, zookeeperPort : Int) = {
+  def brokerConfig(logDir: File, zookeeperPort: Int) = {
     val props = new Properties
     props.put("broker.id", "0")
     props.put("host.name", "localhost")
@@ -58,30 +143,33 @@ object KafkaTestUtils{
     props.put("log.retention.hours", Int.MaxValue.toString)
     new KafkaConfig(props)
   }
- 
-  def tempDir(name : String) = {
+
+  def tempDir(name: String) = {
     val dir = File.createTempFile(name, "")
     dir.delete
     dir.mkdirs
-    dir.deleteOnExit
+    dir.deleteOnExit()
     dir
   }
 
-  class EmbeddedZookeeper(port : Int) {
+  class EmbeddedZookeeper(port: Int) {
+    val connectString = "127.0.0.1:" + port
     val snapshotDir = tempDir("zookeeper-snapshot")
     val logDir = tempDir("zookeeper-log")
     val tickTime = 500
     val zookeeper = new ZooKeeperServer(snapshotDir, logDir, tickTime)
-    val factory = new NIOServerCnxn.Factory(new InetSocketAddress("127.0.0.1", port))
+    val factory = new NIOServerCnxnFactory()
+    factory.configure(new InetSocketAddress("127.0.0.1", port), 10)
     factory.startup(zookeeper)
 
     def shutdown() {
-      zookeeper.shutdown()
       factory.shutdown()
+      zookeeper.shutdown()
       FileUtils.recursiveDelete(snapshotDir)
       FileUtils.recursiveDelete(logDir)
     }
 
   }
+
 }
 

--- a/maths/tests/evcel/maths/InterpolationTest.scala
+++ b/maths/tests/evcel/maths/InterpolationTest.scala
@@ -1,9 +1,9 @@
 package evcel.maths
 
 import evcel.daterange.{Chronological, Day, Month}
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 
-class InterpolationTest extends FunSuite with ShouldMatchers {
+class InterpolationTest extends FunSuite with Matchers {
 
   test("linear interpolation for days") {
     val days = Vector(Day(2015, 1, 1), Day(2015, 1, 2), Day(2015, 1, 6), Day(2015, 1, 7), Day(2015, 1, 8))

--- a/maths/tests/evcel/maths/models/BlackScholesTest.scala
+++ b/maths/tests/evcel/maths/models/BlackScholesTest.scala
@@ -3,9 +3,9 @@ package evcel.maths.models
 import evcel.maths._
 import evcel.maths.utils.DoubleTestUtils
 import org.apache.commons.math3.random.MersenneTwister
-import org.scalatest.{ShouldMatchers, FunSuite}
+import org.scalatest.{Matchers, FunSuite}
 
-class BlackScholesTest extends FunSuite with ShouldMatchers {
+class BlackScholesTest extends FunSuite with Matchers {
   // this is java code for BS converted to scala to test against. taken from
   //  http://www.espenhaug.com/black_scholes.html
   // this is the stock option model so we need to use r = 0.0 and discount the returned value

--- a/maths/tests/evcel/maths/models/MertonReinerRubinsteinBarrierTest.scala
+++ b/maths/tests/evcel/maths/models/MertonReinerRubinsteinBarrierTest.scala
@@ -7,7 +7,7 @@ import evcel.maths.utils.DoubleTestUtils
 import org.apache.commons.math3.random.MersenneTwister
 import org.scalatest._
 
-class MertonReinerRubinsteinBarrierTest extends FunSuite with ShouldMatchers {
+class MertonReinerRubinsteinBarrierTest extends FunSuite with Matchers {
   test("against ss 1") {
     val S = 100
     val k = 3 // rebate

--- a/maths/tests/evcel/maths/models/MonteCarloTest.scala
+++ b/maths/tests/evcel/maths/models/MonteCarloTest.scala
@@ -2,9 +2,9 @@ package evcel.maths.models
 
 import evcel.maths.Call
 import org.apache.commons.math3.random.MersenneTwister
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 
-class MonteCarloTest extends FunSuite with ShouldMatchers {
+class MonteCarloTest extends FunSuite with Matchers {
 
   test("at expiry") {
     val params = MCParams(S = 100, vol = .25, T = 0, b = 0.0)

--- a/project/EVCelBuild.scala
+++ b/project/EVCelBuild.scala
@@ -8,8 +8,8 @@ object EVCelBuild extends Build {
   Properties.setProp("logback.configurationFile", "config/logback-unit-tests.xml")
   val buildOrganisation = "com.evcel"
   val buildVersion = "0.1"
-  val buildScalaVersion = "2.10.4"
-  val buildScalaMajorVersion = "2.10"
+  val buildScalaVersion = "2.11.5"
+  val buildScalaMajorVersion = "2.11"
 
   lazy val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true),
@@ -21,11 +21,10 @@ object EVCelBuild extends Build {
 
   lazy val utils = module("utils").settings(
     libraryDependencies ++= Seq(
-      "com.github.stacycurl" % "pimpathon-core_2.10" % "1.1.0",
-      "org.scalaz" % "scalaz-core_2.10" % "7.1.0"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+      "com.github.stacycurl" %% "pimpathon-core" % "1.1.0",
+      "org.scalaz" %% "scalaz-core" % "7.1.1",
+      "com.chuusai" %% "shapeless" % "2.0.0"
+    )
   )
 
   lazy val maths = module("maths").settings(
@@ -37,81 +36,61 @@ object EVCelBuild extends Build {
       "org.scalanlp" %% "breeze" % "0.10",
       "org.scalanlp" %% "breeze-natives" % "0.10"
     ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests",
     resolvers += "opengamma" at "http://maven.opengamma.com/nexus/content/groups/public/"
   ).dependsOn(utils, daterange)
 
   lazy val daterange = module("daterange").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(utils)
 
   lazy val quantity = module("quantity").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(maths, utils)
 
   lazy val pivot = module("pivot").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(quantity, daterange)
 
   lazy val instrument = module("instrument").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(curve % "compile->compile;test->test", quantity % "test->test")
 
   lazy val valuation = module("valuation").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(instrument, curve % "compile->compile;test->test", quantity % "test->test")
   
   lazy val reports = module("reports").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(pivot, valuation % "compile->compile;test->test", instrument % "compile->compile;test->test", curve % "test->test", quantity % "test->test")
 
   lazy val xl = module("xl").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(reports)
 
   lazy val referencedata = module("referencedata").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(daterange, quantity, utils % "test->test")
 
   lazy val curve = module("curve").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
     ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests",
     resourceDirectory in Test := baseDirectory.value / "test-resources"
   ).dependsOn(calendar, utils, quantity %  "compile->compile;test->test",
       daterange, referencedata % "compile->compile;test->test", utils % "test->test")
@@ -119,7 +98,7 @@ object EVCelBuild extends Build {
   lazy val eventstore = module("eventstore").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-      "org.apache.kafka" % s"kafka_$buildScalaMajorVersion" % "0.8.1.1" exclude ("org.slf4j", "slf4j-log4j12"),
+      "org.apache.kafka" % s"kafka_$buildScalaMajorVersion" % "0.8.2.0" exclude ("org.slf4j", "slf4j-log4j12"),
       "org.apache.zookeeper" % "zookeeper" % "3.3.4" exclude ("org.slf4j", "slf4j-log4j12"),
       "io.spray" % s"spray-json_$buildScalaMajorVersion" % "1.2.6"
     ).map(
@@ -128,42 +107,32 @@ object EVCelBuild extends Build {
       _.exclude("javax.jms", "jms")
     ).map(
       _.exclude("com.sun.jmx", "jmxri")
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(instrument, referencedata, curve, quantity, utils)
 
   lazy val calendar = module("calendar").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(daterange)
 
 
   lazy val marketdatastore = module("marketdatastore").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(eventstore % "compile->compile;test->test", curve % "compile->compile;test->test")
 
   lazy val referencedatastore = module("referencedatastore").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(referencedata, eventstore % "compile->compile;test->test")
 
   lazy val tradestore = module("tradestore").settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-    ),
-    scalaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "tests"
+    )
   ).dependsOn(instrument, eventstore % "compile->compile;test->test")
 
   lazy val server = module("server").settings(
@@ -176,6 +145,9 @@ object EVCelBuild extends Build {
       base = file(name),
       settings = buildSettings
         ++ addCommandAlias("gen-idea-with-sources", ";update-classifiers;update-sbt-classifiers;gen-idea sbt-classifiers")
-    )
+    ).settings(
+        scalaSource in Compile := baseDirectory.value / "src",
+        scalaSource in Test := baseDirectory.value / "tests"
+      )
   }
 }

--- a/quantity/tests/evcel/quantity/UOMRatioTest.scala
+++ b/quantity/tests/evcel/quantity/UOMRatioTest.scala
@@ -1,8 +1,8 @@
 package evcel.quantity
 
-import org.scalatest.{ ShouldMatchers, FunSuite }
+import org.scalatest.{ Matchers, FunSuite }
 
-class UOMRatioTest extends FunSuite with ShouldMatchers {
+class UOMRatioTest extends FunSuite with Matchers {
 
   test("test reduce") {
     val usd = UOMRatio(3, 1)

--- a/referencedata/tests/evcel/referencedata/market/FXMarketTest.scala
+++ b/referencedata/tests/evcel/referencedata/market/FXMarketTest.scala
@@ -5,9 +5,9 @@ import evcel.quantity.UOM._
 import evcel.referencedata.calendar.Calendar.Holidays
 import evcel.referencedata.calendar.{SimpleCalendar, Calendars, TestCalendars}
 import evcel.referencedata.{TestFuturesExpiryRules, ReferenceData}
-import org.scalatest.{ShouldMatchers, FunSuite}
+import org.scalatest.{Matchers, FunSuite}
 
-class FXMarketTest extends FunSuite with ShouldMatchers {
+class FXMarketTest extends FunSuite with Matchers {
   val rd = testRefData()
   val today = Day(2014, 11, 3) // monday
   val tomorrow = today + 1

--- a/referencedata/tests/evcel/referencedata/market/IndexLabelTest.scala
+++ b/referencedata/tests/evcel/referencedata/market/IndexLabelTest.scala
@@ -1,8 +1,8 @@
 package evcel.referencedata.market
 
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 
-class IndexLabelTest extends FunSuite with ShouldMatchers {
+class IndexLabelTest extends FunSuite with Matchers {
 
   test("test index parsing") {
     val indexes = List(

--- a/valuation/tests/evcel/valuation/ValuationTest.scala
+++ b/valuation/tests/evcel/valuation/ValuationTest.scala
@@ -12,14 +12,14 @@ import evcel.quantity.UOM._
 import evcel.quantity.{BDQty, Percent, Qty}
 import evcel.referencedata.Level
 import evcel.referencedata.market.{IndexLabelSpread, IndexLabel}
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 import scala.language.reflectiveCalls
 import scalaz.{Show, Equal}
 import scala.math.BigDecimal
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import evcel.utils.EitherTestPimps
 
-trait ValuationTest extends FunSuite with ShouldMatchers 
+trait ValuationTest extends FunSuite with Matchers
   with EitherTestPimps
 {
   implicit val valuer = new DefaultValuer

--- a/valuation/tests/evcel/valuation/ValuerTest.scala
+++ b/valuation/tests/evcel/valuation/ValuerTest.scala
@@ -9,13 +9,13 @@ import evcel.instrument.{CommoditySwap, FuturesOption}
 import evcel.maths.{EuropeanOption, Call}
 import evcel.quantity.Qty
 import evcel.referencedata.market.IndexLabel
-import org.scalatest.{ShouldMatchers, FunSuite}
+import org.scalatest.{Matchers, FunSuite}
 import evcel.quantity.UOM._
 import scala.language.reflectiveCalls
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import evcel.utils.EitherTestPimps
 
-class ValuerTest extends FunSuite with ShouldMatchers with EitherTestPimps {
+class ValuerTest extends FunSuite with Matchers with EitherTestPimps {
 
   test("test key recording for futures") {
     val vc = UnitTestingEnvironment.Null((1 / Oct / 2014).endOfDay)


### PR DESCRIPTION
there was a problem with matching on Iterable[Type], where Type would
have been erased. That's an error in 2.11. So using shapeless to get
around the type erasure. We should probably not be matching on the type
but that's a bigger change.